### PR TITLE
feat: use container envionment to run the script. add display grid photos from dist mat

### DIFF
--- a/config/stage2/transreid_256_veri_gan.yml
+++ b/config/stage2/transreid_256_veri_gan.yml
@@ -1,12 +1,12 @@
 MODEL:
   PRETRAIN_CHOICE: 'self'
-  PRETRAIN_PATH: './reid_model/checkpoints/stage1/transreid_256/transformer_40.pth'
+  PRETRAIN_PATH: '/models/reid_model/checkpoints/stage1/transreid_256/transformer_40.pth'
   METRIC_LOSS_TYPE: 'triplet'
   IF_LABELSMOOTH: 'off'
   IF_WITH_CENTER: 'no'
   NAME: 'transformer'
   NO_MARGIN: True
-  DEVICE_ID: ('7')
+  DEVICE_ID: ('0')
   Transformer_TYPE: 'vit_base_patch16_224_TransReID'
   STRIDE_SIZE: [14, 14]
 
@@ -49,7 +49,7 @@ TEST:
   IMS_PER_BATCH: 128
   RE_RANKING: True
   RE_RANKING_TRACK: True
-  WEIGHT: './logs/stage2/transreid_256/v1/transformer_2.pth'
+  WEIGHT: '/models/logs/stage2/transreid_256/v1/transformer_2.pth'
   NECK_FEAT: 'after'
   FEAT_NORM: 'yes'
   FLIP_FEATS: 'no'

--- a/filepath.py
+++ b/filepath.py
@@ -1,0 +1,6 @@
+import os
+
+MODEL_PATH="/models"
+
+def modelpath_join(suffix_path):
+    return os.path.join(MODEL_PATH, suffix_path)

--- a/gan/model.py
+++ b/gan/model.py
@@ -10,6 +10,7 @@ from torch.nn import functional as F
 from .networks import get_norm_layer, CustomPoseGenerator, NLayerDiscriminator, remove_module_key, \
     print_network, OrthogonalEncoder, IDDiscriminator
 
+from filepath import modelpath_join
 
 class GaussianSmoothing(nn.Module):
     """
@@ -125,13 +126,13 @@ class Model(nn.Module):
         self.net_Dp = NLayerDiscriminator(3 + 20, norm_layer=self.norm_layer)
 
         self._load_state_dict(self.net_E,
-                              '/home/ANYCOLOR2434/AICITY2021_Track2_DMT/AICITY2021_Track2_DMT-main/code_sw/weights/GAN_stage_2/17_net_E.pth')
+                              modelpath_join('code_sw/weights/GAN_stage_2/17_net_E.pth'))
         self._load_state_dict(self.net_G,
-                              '/home/ANYCOLOR2434/AICITY2021_Track2_DMT/AICITY2021_Track2_DMT-main/code_sw/weights/GAN_stage_2/17_net_G.pth')
+                              modelpath_join('code_sw/weights/GAN_stage_2/17_net_G.pth'))
         self._load_state_dict(self.net_Di,
-                              '/home/ANYCOLOR2434/AICITY2021_Track2_DMT/AICITY2021_Track2_DMT-main/code_sw/weights/GAN_stage_2/17_net_Di.pth')
+                              modelpath_join('code_sw/weights/GAN_stage_2/17_net_Di.pth'))
         self._load_state_dict(self.net_Dp,
-                              '/home/ANYCOLOR2434/AICITY2021_Track2_DMT/AICITY2021_Track2_DMT-main/code_sw/weights/GAN_stage_2/17_net_Dp.pth')
+                              modelpath_join('code_sw/weights/GAN_stage_2/17_net_Dp.pth'))
 
         self.net_E = nn.DataParallel(self.net_E).to(self.device)
         self.net_G = nn.DataParallel(self.net_G).to(self.device)

--- a/load_distmat.py
+++ b/load_distmat.py
@@ -1,0 +1,58 @@
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+from PIL import Image
+
+def draw_ranked_photo(csvfile: str, output: str, topN: int):
+    inputcsv = pd.read_csv(csvfile)
+    # do transportT such that each row represents one gallery path with one distance
+    inputcsvT = inputcsv.T
+
+    # skip the first row as it displays query information
+    inputcsvT = inputcsvT[1:]
+
+    # convert the 0th column type to number
+    inputcsvTNum = pd.to_numeric(inputcsvT[0])
+    inputcsvTNumTopN = inputcsvTNum.nsmallest(topN)
+    ims = []
+    for i in range(0, topN):
+      path = inputcsvTNumTopN.index[i]
+      score = inputcsvTNumTopN[i]
+      # replace path
+      static_path = path.replace('../AIC21/veri_pose', '/models/gallery/veri_pose')
+      ims.append(Image.open(static_path))
+
+    savegrid(ims, output, 4, 4, True, False)
+
+def savegrid(ims, save_path:str, rows=None, cols=None, fill=True, showax=False):
+    if rows is None != cols is None:
+        raise ValueError("Set either both rows and cols or neither.")
+
+    if rows is None:
+        rows = len(ims)
+        cols = 1
+
+    gridspec_kw = {'wspace': 0, 'hspace': 0} if fill else {}
+    fig,axarr = plt.subplots(rows, cols, gridspec_kw=gridspec_kw)
+
+    if fill:
+        bleed = 0
+        fig.subplots_adjust(left=bleed, bottom=bleed, right=(1 - bleed), top=(1 - bleed))
+
+    for ax,im in zip(axarr.ravel(), ims):
+        ax.imshow(im)
+        if not showax:
+            ax.set_axis_off()
+
+    kwargs = {'pad_inches': .01} if fill else {}
+    fig.savefig(save_path, **kwargs)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input_csv_matrics', dest='inputcsvmatrics', type=str, default='')
+    parser.add_argument('--output', dest='output', type=str, default='')
+    parser.add_argument('--top', dest='topN', type=int, default=16)
+
+    args = parser.parse_args()
+    draw_ranked_photo(args.inputcsvmatrics, args.output, args.topN)

--- a/reid_model/backbones/vit_pytorch.py
+++ b/reid_model/backbones/vit_pytorch.py
@@ -28,7 +28,8 @@ from itertools import repeat
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch._six import container_abcs
+#from torch._six import container_abcs
+import collections.abc as container_abcs
 
 
 # From PyTorch internals

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,13 +35,13 @@ Markdown==3.2.2
 
 mmcv==1.1.5
 
-numpy==1.18.0
+numpy==1.18.5
 oauthlib==3.0.1
 olefile==0.46
 opencv-python==4.4.0.44
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==7.2.0
+Pillow==8.4.0
 prompt-toolkit==1.0.15
 protobuf==3.13.0
 ptyprocess==0.6.0
@@ -61,7 +61,7 @@ requests==2.24.0
 rsa==4.6
 scikit-image==0.16.2
 scikit-learn==0.23.2
-scipy==1.2.0
+scipy==1.9.0
 
 simplegeneric==0.8.1
 six==1.15.0
@@ -73,8 +73,9 @@ termcolor==1.1.0
 threadpoolctl==2.1.0
 timm==0.3.4
 
-torch==1.6.0
-torchvision==0.7.0
+# provisioning by the container itself
+#torch==1.6.0
+#torchvision==0.7.0
 
 tqdm==4.49.0
 traitlets==4.3.3

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker run -e NVIDIA_VISIBLE_DEVICES=0 \
+    -itd -v /home/ubuntu/workspace:/workspace -v /home/ubuntu/models:/models pytorch/pytorch:1.11.0-cuda11.3-cudnn8-devel
+
+# use docker exec <container-id> /bin/bash to access the container


### PR DESCRIPTION
this PR improves the following areas:

1. use container image to run the code. The currently running version is pytorch:1.11.0-cuda11.3-cudnn8-devel.
we also require to mount volumns (/workspace and /models) with the containers. for /workspace is where you code is based and /models should contains model and gallery photos.
3. add display grid photos with dist mat